### PR TITLE
Add a couple of missing #include directives

### DIFF
--- a/src/internal/math.h
+++ b/src/internal/math.h
@@ -2,6 +2,7 @@
 #define MATH_H
 
 #include "nurbs.h"
+#include <algorithm>
 #include <limits>
 
 namespace adsk

--- a/src/internal/math.h
+++ b/src/internal/math.h
@@ -2,6 +2,7 @@
 #define MATH_H
 
 #include "nurbs.h"
+#include <limits>
 
 namespace adsk
 {


### PR DESCRIPTION
In `src/internal/math`, `std::numeric_limits` is used from `<limits>`, and `std::max` and `std::min` are used from `<algorithm>`. Include these standard-library headers where they are used rather than relying on their inclusion by implicit or indirect means.

Fixes failure to compile on GCC 14.0.1 in Fedora Rawhide.